### PR TITLE
Save ODF as .mat file

### DIFF
--- a/mtex-plotter/sxrd_texture_plotter.m
+++ b/mtex-plotter/sxrd_texture_plotter.m
@@ -189,8 +189,8 @@ for i = 1:number_of_stages
         return;
     end
     
-    % save odf variable as file
-    %save(strcat(outputDir.(stage),'/', phase, '_ODF.mat'), 'odf');
+    save odf variable as file
+    save(strcat(outputDir.(stage),'/', phase, '_ODF.mat'), 'odf');
 end
 
 %% Plot the Texture Variation


### PR DESCRIPTION
Also save ODF as a matlab variable file for use in matflow-damask simulations.